### PR TITLE
Update vision-stays-app-lb.yaml

### DIFF
--- a/kubernetes/vision-stays-app-lb.yaml
+++ b/kubernetes/vision-stays-app-lb.yaml
@@ -2,33 +2,31 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: vision-stays-app-ing
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "nginx"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: tls-secret
   rules:
   - http:
       paths:
-      - path: /vs-hotels-dm
-        pathType: Prefix
+      - path: /vs-hotels
+        pathType: ImplementationSpecific
         backend:
           service:
             name: hotel-service-svc
-            port: 
+            port:
               number: 8081
       - path: /vs-customers
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: customer-service-svc
-            port: 
-              number: 8081            
+            port:
+              number: 8081
       - path: /vs-bookings
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: booking-service-svc
             port:
-              number: 8081        
+              number: 8081


### PR DESCRIPTION
removed below lines as it was causing code issues with the new nginx-ingress deploy version 1.3.0
annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /
    kubernetes.io/ingress.class: "nginx"

added line 
ingressClassName: nginx

removed -dm from - path: /vs-hotels-dm

changed the pathType to ImplementationSpecific for all the service

removed all whitespaces